### PR TITLE
Extra galera variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,9 @@
 
 
 - name: Install ProxySQL
-  apt: name=proxysql state=present
+  apt: 
+    name: proxysql
+    state: latest
 
 
 - name: Recursively change ownership of /var/lib/proxysql folder

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -192,6 +192,8 @@ mysql_galera_hostgroups=
         reader_hostgroup = {{ galera_hostgroup.reader_hostgroup }}
         offline_hostgroup = {{ galera_hostgroup.offline_hostgroup }}
         max_writers = {{ galera_hostgroup.max_writers if galera_hostgroup.max_writers is defined else 1 }}
+        writer_is_also_reader = {{ galera_hostgroup.writer_is_also_reader if galera_hostgroup.writer_is_also_reader is defined else 1 }}
+        max_transactions_behind = {{ galera_hostgroup.max_transactions_behind if galera_hostgroup.max_transactions_behind is defined else 0 }}
         comment = "{{ galera_hostgroup.comment }}"
     }
     {%- if not loop.last -%}


### PR DESCRIPTION
writer_is_also_reader now enabled by default, otherwise reader hostgroup is not filled 