### PR TITLE
Skip adding monitoring user to ProxySQL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,13 @@
 proxysql_cnf_path: '/etc'
 proxysql_template: 'proxysql.cnf.j2'
 
-# admin variables
-proxysql_admin_credentials: 'admin:admin'
-proxysql_admin_ifaces: '0.0.0.0:6032'
+# admin credentials
+proxysql_admin_username: 'admin'
+proxysql_admin_password: 'admin'
+
+# admin interface
+proxysql_admin_bind_address: '0.0.0.0'
+proxysql_admin_bind_port: 6032
 proxysql_admin_refresh_interval: 2000
 
 # mysql variables
@@ -95,3 +99,11 @@ proxysql_mysql_galera_hostgroups: []
 #   reader_hostgroup: 80
 #   offline_hostgroup: 90
 #   comment: "galera cluster 1"
+
+# Install MySQL client and place /root/.my.cnf for easy ProxySQL administration
+proxysql_cli_install_config: True
+# Install a MySQL client to be able to login to ProxySQL
+proxysql_cli_install_client: True
+# When installing a client, which flavor are we installing?
+proxysql_cli_client_package: "mariadb-client"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
----
+# Repository configuration
+proxysql_apt_version: '2.0.*'
+
 # defaults file for proxySQL
 proxysql_cnf_path: '/etc'
 proxysql_template: 'proxysql.cnf.j2'

--- a/tasks/admin-client.yml
+++ b/tasks/admin-client.yml
@@ -1,10 +1,3 @@
-- name: "Check parameters upgraded"
-  assert:
-    that: 
-     - "proxysql_admin_credentials is not defined"
-     - "proxysql_admin_ifaces is not defined"
-    fail_msg: "Please upgrade your group vars to the new style configuration"
-
 - name: "Install MySQL CLI client"
   package: 
     name: "{{ proxysql_cli_client_package }}"

--- a/tasks/admin-client.yml
+++ b/tasks/admin-client.yml
@@ -1,0 +1,17 @@
+- name: "Check parameters upgraded"
+  assert:
+    that: 
+     - "proxysql_admin_credentials is not defined"
+     - "proxysql_admin_ifaces is not defined"
+    fail_msg: "Please upgrade your group vars to the new style configuration"
+
+- name: "Install MySQL CLI client"
+  package: 
+    name: "{{ proxysql_cli_client_package }}"
+  when: proxysql_cli_install_client
+
+- name: "Write configuration file"
+  template:
+    src: "root_my.cnf.j2"
+    dest: "/root/.my.cnf"
+  when: proxysql_cli_install_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
   apt: 
     name: "proxysql={{ proxysql_apt_version }}"
     state: "{{ 'latest' if proxysql_apt_version[-1] == '*' else 'present' }}"
-    dpkg_options: force-confdef,force-confold,force-downgrade
+    force: yes # Allow downgrades
 
 
 - name: Recursively change ownership of /var/lib/proxysql folder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
     state: directory
     owner: proxysql
     group: proxysql
-PM 
+
 
 - name: APT | Install ProxySQL key
   apt_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
----
-### Installation
+- name: "Check parameters upgraded"
+  assert:
+    that: 
+     - "proxysql_admin_credentials is not defined"
+     - "proxysql_admin_ifaces is not defined"
+    fail_msg: "Please upgrade your group vars to the new style configuration"
 
 
 - name: Ensure lsb-release is installed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,3 +71,7 @@
     path: /var/lib/proxysql/proxysql.db
     state: absent
   when: config.changed
+
+- name: "Installing CLI client and/or admin interface configuration"
+  import_tasks: admin-client.yml
+  when: proxysql_cli_install_client or proxysql_cli_install_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,10 +36,10 @@
   apt_repository: repo='deb https://repo.proxysql.com/ProxySQL/proxysql-2.0.x/{{ ansible_distribution_release }}/ ./' state=present
 
 
-- name: Install ProxySQL
+- name: Install, upgrade or downgrade ProxySQL
   apt: 
-    name: proxysql
-    state: latest
+    name: "proxysql={{ proxysql_apt_version }}"
+    state: "{{ 'latest' if proxysql_apt_version[-1] == '*' else 'present' }}"
 
 
 - name: Recursively change ownership of /var/lib/proxysql folder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
   apt: 
     name: "proxysql={{ proxysql_apt_version }}"
     state: "{{ 'latest' if proxysql_apt_version[-1] == '*' else 'present' }}"
+    dpkg_options: force-confdef,force-confold,force-downgrade
 
 
 - name: Recursively change ownership of /var/lib/proxysql folder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,9 +36,9 @@
   apt_repository: repo='deb https://repo.proxysql.com/ProxySQL/proxysql-2.0.x/{{ ansible_distribution_release }}/ ./' state=present
 
 
-- name: Install ProxySQL
+- name: Install, upgrade or downgrade ProxySQL
   apt: 
-    name: proxysql
+    name: "proxysql={{ proxysql_apt_version }}"
     state: latest
 
 

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -149,10 +149,10 @@ mysql_query_rules:
         schemaname = "{{ mysql_query_rule.schemaname }}"
         {% endif %}
         {% if mysql_query_rule.flagIN is defined %}
-        flagIN = "{{ mysql_query_rule.flagIN }}" # default 0
+        flagIN = {{ mysql_query_rule.flagIN | int }} # default 0
         {% endif %}
         {% if mysql_query_rule.flagOUT is defined %}
-        flagOUT = "{{ mysql_query_rule.flagOUT }}"
+        flagOUT = {{ mysql_query_rule.flagOUT | int }}
         {% endif %}
         {% if mysql_query_rule.client_addr is defined %}
         client_addr = "{{ mysql_query_rule.client_addr }}"
@@ -161,7 +161,7 @@ mysql_query_rules:
         proxy_addr = "{{ mysql_query_rule.proxy_addr }}"
         {% endif %}
         {% if mysql_query_rule.proxy_port is defined %}
-        proxy_port = "{{ mysql_query_rule.proxy_port }}"
+        proxy_port = {{ mysql_query_rule.proxy_porti | int }}
         {% endif %}
         {% if mysql_query_rule.match_digest is defined %}
         match_digest = "{{ mysql_query_rule.match_digest }}"
@@ -170,40 +170,40 @@ mysql_query_rules:
         match_pattern = "{{ mysql_query_rule.match_pattern }}"
         {% endif %}
         {% if mysql_query_rule.negate_match_pattern is defined %}
-        negate_match_pattern = "{{ mysql_query_rule.negate_match_pattern }}" # default 0
+        negate_match_pattern = {{ mysql_query_rule.negate_match_pattern | int }} # default 0
         {% endif %}
         {% if mysql_query_rule.re_modifiers is defined %}
         re_modifiers = "{{ mysql_query_rule.re_modifiers }}" # default CASELESS
         {% endif %}
         {% if mysql_query_rule.destination_hostgroup is defined %}
-        destination_hostgroup = "{{ mysql_query_rule.destination_hostgroup }}"
+        destination_hostgroup = {{ mysql_query_rule.destination_hostgroup | int }}
         {% endif %}
         {% if mysql_query_rule.cache_ttl is defined %}
-        cache_ttl = "{{ mysql_query_rule.cache_ttl }}"
+        cache_ttl = {{ mysql_query_rule.cache_ttl | int }}
         {% endif %}
         {% if mysql_query_rule.cache_empty_result is defined %}
-        cache_empty_result = "{{ mysql_query_rule.cache_empty_result }}"
+        cache_empty_result = {{ mysql_query_rule.cache_empty_result | int }}
         {% endif %}
         {% if mysql_query_rule.cache_timeout is defined %}
-        cache_timeout = "{{ mysql_query_rule.cache_timeout }}"
+        cache_timeout = {{ mysql_query_rule.cache_timeout | int }}
         {% endif %}
         {% if mysql_query_rule.timeout is defined %}
-        timeout = "{{ mysql_query_rule.timeout }}"
+        timeout = {{ mysql_query_rule.timeout | int }}
         {% endif %}
         {% if mysql_query_rule.retries is defined %}
-        retries = "{{ mysql_query_rule.retries }}"
+        retries = {{ mysql_query_rule.retries | int }}
         {% endif %}
         {% if mysql_query_rule.delay is defined %}
-        delay = "{{ mysql_query_rule.delay }}"
+        delay = {{ mysql_query_rule.delay | int }}
         {% endif %}
         {% if mysql_query_rule.next_query_flagIN is defined %}
-        next_query_flagIN = "{{ mysql_query_rule.next_query_flagIN }}"
+        next_query_flagIN = {{ mysql_query_rule.next_query_flagIN | int }}
         {% endif %}
         {% if mysql_query_rule.mirror_flagOUT is defined %}
-        mirror_flagOUT = "{{ mysql_query_rule.mirror_flagOUT }}"
+        mirror_flagOUT = {{ mysql_query_rule.mirror_flagOUT | int }}
         {% endif %}
         {% if mysql_query_rule.mirror_hostgroup is defined %}
-        mirror_hostgroup = "{{ mysql_query_rule.mirror_hostgroup }}"
+        mirror_hostgroup = {{ mysql_query_rule.mirror_hostgroup | int }}
         {% endif %}
         {% if mysql_query_rule.error_msg is defined %}
         error_msg = "{{ mysql_query_rule.error_msg }}"
@@ -212,18 +212,18 @@ mysql_query_rules:
         OK_msg = "{{ mysql_query_rule.OK_msg }}"
         {% endif %}
         {% if mysql_query_rule.sticky_conn is defined %}
-        sticky_conn = "{{ mysql_query_rule.sticky_conn }}"
+        sticky_conn = {{ mysql_query_rule.sticky_conn | int }}
         {% endif %}
         {% if mysql_query_rule.multiplex is defined %}
-        multiplex = "{{ mysql_query_rule.multiplex }}"
+        multiplex = {{ mysql_query_rule.multiplex | int }}
         {% endif %}
         {% if mysql_query_rule.gtid_from_hostgroup is defined %}
-        gtid_from_hostgroup = "{{ mysql_query_rule.gtid_from_hostgroup }}"
+        gtid_from_hostgroup = {{ mysql_query_rule.gtid_from_hostgroup | int }}
         {% endif %}
         {% if mysql_query_rule.log is defined %}
-        log = "{{ mysql_query_rule.log }}"
+        log = {{ mysql_query_rule.log | int }}
         {% endif %}
-        apply = {{ mysql_query_rule.apply }}
+        apply = {{ mysql_query_rule.apply | int }}
         {% if mysql_query_rule.comment is defined %}
         comment = "{{ mysql_query_rule.comment }}"
         {% endif %}

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -192,8 +192,6 @@ mysql_galera_hostgroups=
         reader_hostgroup = {{ galera_hostgroup.reader_hostgroup }}
         offline_hostgroup = {{ galera_hostgroup.offline_hostgroup }}
         max_writers = {{ galera_hostgroup.max_writers if galera_hostgroup.max_writers is defined else 1 }}
-        writer_is_also_reader = {{ galera_hostgroup.writer_is_also_reader if galera_hostgroup.writer_is_also_reader else 1 }}
-        max_transactions_behind = {{ galera_hostgroup.max_transactions_behind if galera_hostgroup.max_transactions_behind else 0 }}
         comment = "{{ galera_hostgroup.comment }}"
     }
     {%- if not loop.last -%}

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -40,8 +40,8 @@ errorlog="/var/lib/proxysql/proxysql.log"
 
 admin_variables=
 {
-    admin_credentials="{{ proxysql_admin_credentials }}"
-    mysql_ifaces="{{ proxysql_admin_ifaces }}"
+    admin_credentials="{{ proxysql_admin_username }}:{{ proxysql_admin_password }}"
+    mysql_ifaces="{{ proxysql_admin_bind_address }}:{{ proxysql_admin_bind_port }}"
     {% if proxysql_admin_refresh_interval is defined %}
         refresh_interval = {{ proxysql_admin_refresh_interval }}
     {% endif %}

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -142,9 +142,91 @@ mysql_query_rules:
     {
         rule_id = {{ mysql_query_rule.rule_id }}
         active = {{ mysql_query_rule.active }}
+        {% if mysql_query_rule.username is defined %}
+        username = "{{ mysql_query_rule.username }}"
+        {% endif %}
+        {% if mysql_query_rule.schemaname is defined %}
+        schemaname = "{{ mysql_query_rule.schemaname }}"
+        {% endif %}
+        {% if mysql_query_rule.flagIN is defined %}
+        flagIN = "{{ mysql_query_rule.flagIN }}" # default 0
+        {% endif %}
+        {% if mysql_query_rule.flagOUT is defined %}
+        flagOUT = "{{ mysql_query_rule.flagOUT }}"
+        {% endif %}
+        {% if mysql_query_rule.client_addr is defined %}
+        client_addr = "{{ mysql_query_rule.client_addr }}"
+        {% endif %}
+        {% if mysql_query_rule.proxy_addr is defined %}
+        proxy_addr = "{{ mysql_query_rule.proxy_addr }}"
+        {% endif %}
+        {% if mysql_query_rule.proxy_port is defined %}
+        proxy_port = "{{ mysql_query_rule.proxy_port }}"
+        {% endif %}
+        {% if mysql_query_rule.match_digest is defined %}
+        match_digest = "{{ mysql_query_rule.match_digest }}"
+        {% endif %}
+        {% if mysql_query_rule.match_pattern is defined %}
         match_pattern = "{{ mysql_query_rule.match_pattern }}"
-        destination_hostgroup = {{ mysql_query_rule.destination_hostgroup }}
+        {% endif %}
+        {% if mysql_query_rule.negate_match_pattern is defined %}
+        negate_match_pattern = "{{ mysql_query_rule.negate_match_pattern }}" # default 0
+        {% endif %}
+        {% if mysql_query_rule.re_modifiers is defined %}
+        re_modifiers = "{{ mysql_query_rule.re_modifiers }}" # default CASELESS
+        {% endif %}
+        {% if mysql_query_rule.destination_hostgroup is defined %}
+        destination_hostgroup = "{{ mysql_query_rule.destination_hostgroup }}"
+        {% endif %}
+        {% if mysql_query_rule.cache_ttl is defined %}
+        cache_ttl = "{{ mysql_query_rule.cache_ttl }}"
+        {% endif %}
+        {% if mysql_query_rule.cache_empty_result is defined %}
+        cache_empty_result = "{{ mysql_query_rule.cache_empty_result }}"
+        {% endif %}
+        {% if mysql_query_rule.cache_timeout is defined %}
+        cache_timeout = "{{ mysql_query_rule.cache_timeout }}"
+        {% endif %}
+        {% if mysql_query_rule.timeout is defined %}
+        timeout = "{{ mysql_query_rule.timeout }}"
+        {% endif %}
+        {% if mysql_query_rule.retries is defined %}
+        retries = "{{ mysql_query_rule.retries }}"
+        {% endif %}
+        {% if mysql_query_rule.delay is defined %}
+        delay = "{{ mysql_query_rule.delay }}"
+        {% endif %}
+        {% if mysql_query_rule.next_query_flagIN is defined %}
+        next_query_flagIN = "{{ mysql_query_rule.next_query_flagIN }}"
+        {% endif %}
+        {% if mysql_query_rule.mirror_flagOUT is defined %}
+        mirror_flagOUT = "{{ mysql_query_rule.mirror_flagOUT }}"
+        {% endif %}
+        {% if mysql_query_rule.mirror_hostgroup is defined %}
+        mirror_hostgroup = "{{ mysql_query_rule.mirror_hostgroup }}"
+        {% endif %}
+        {% if mysql_query_rule.error_msg is defined %}
+        error_msg = "{{ mysql_query_rule.error_msg }}"
+        {% endif %}
+        {% if mysql_query_rule.OK_msg is defined %}
+        OK_msg = "{{ mysql_query_rule.OK_msg }}"
+        {% endif %}
+        {% if mysql_query_rule.sticky_conn is defined %}
+        sticky_conn = "{{ mysql_query_rule.sticky_conn }}"
+        {% endif %}
+        {% if mysql_query_rule.multiplex is defined %}
+        multiplex = "{{ mysql_query_rule.multiplex }}"
+        {% endif %}
+        {% if mysql_query_rule.gtid_from_hostgroup is defined %}
+        gtid_from_hostgroup = "{{ mysql_query_rule.gtid_from_hostgroup }}"
+        {% endif %}
+        {% if mysql_query_rule.log is defined %}
+        log = "{{ mysql_query_rule.log }}"
+        {% endif %}
         apply = {{ mysql_query_rule.apply }}
+        {% if mysql_query_rule.comment is defined %}
+        comment = "{{ mysql_query_rule.comment }}"
+        {% endif %}
     }
     {%- if not loop.last -%}
     ,

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -192,6 +192,8 @@ mysql_galera_hostgroups=
         reader_hostgroup = {{ galera_hostgroup.reader_hostgroup }}
         offline_hostgroup = {{ galera_hostgroup.offline_hostgroup }}
         max_writers = {{ galera_hostgroup.max_writers if galera_hostgroup.max_writers is defined else 1 }}
+        writer_is_also_reader = {{ galera_hostgroup.writer_is_also_reader if galera_hostgroup.writer_is_also_reader else 1 }}
+        max_transactions_behind = {{ galera_hostgroup.max_transactions_behind if galera_hostgroup.max_transactions_behind else 0 }}
         comment = "{{ galera_hostgroup.comment }}"
     }
     {%- if not loop.last -%}

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -111,6 +111,7 @@ mysql_servers =
 mysql_users:
 (
     {% for mysql_user in proxysql_mysql_users %}
+    {% if mysql_user.username != proxysql_mysql_monitor_username %}
     {
         username = "{{ mysql_user.username }}"
         password = "{{ mysql_user.password }}"
@@ -129,6 +130,7 @@ mysql_users:
     }
     {%- if not loop.last -%}
     ,
+    {% endif %}
     {% endif %}
     {% endfor %}
 )

--- a/templates/root_my.cnf.j2
+++ b/templates/root_my.cnf.j2
@@ -1,0 +1,6 @@
+[mysql]
+host={{ '127.0.0.1' if proxysql_admin_bind_address == '0.0.0.0' else proxysql_admin_bind_address }}
+port={{ proxysql_admin_bind_port }}
+user={{ proxysql_admin_username }}
+password={{ proxysql_admin_password }}
+


### PR DESCRIPTION
It is unneeded to add the ProxySQL monitoring username in the ProxySQL configuration. Application monitoring should use a different account.

(This way users can pass the same list of accounts to their MariaDB installation role as to this role.)