### PR TITLE
Workaround for issue 1254

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,9 @@ proxysql_mysql_galera_hostgroups:
 
 # Install MySQL client and place /root/.my.cnf for easy ProxySQL administration
 proxysql_cli_install_config: True
+# Install a cronjob that executes `LOAD MYSQL SERVERS INTO RUNTIME` every 15 minutes as a work-around for issue
+# https://github.com/sysown/proxysql/issues/1254
+proxysql_install_1254_workaround: True
 # Install a MySQL client to be able to login to ProxySQL
 proxysql_cli_install_client: True
 # When installing a client, which flavor are we installing?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ proxysql_mysql_ping_timeout_server: 500
 proxysql_mysql_commands_stats: true
 proxysql_mysql_sessions_sort: true
 proxysql_mysql_connect_retries_on_failure: 10
+proxysql_mysql_hostgroup_manager_verbose: 2
 
 # define all MySQL servers
 proxysql_mysql_servers: []

--- a/tasks/admin-client.yml
+++ b/tasks/admin-client.yml
@@ -3,14 +3,6 @@
     name: "{{ proxysql_cli_client_package }}"
   when: proxysql_cli_install_client
 
-- name: "Install work-around for issue 1254"
-  cron:
-    cron_file: "ansible_1254_workaround"
-    minute: "1,16,31,46"
-    user: "root"
-    job: '/usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"'
-  when: proxysql_cli_install_config and proxysql_install_1254_workaround
-
 - name: "Write configuration file"
   template:
     src: "root_my.cnf.j2"

--- a/tasks/admin-client.yml
+++ b/tasks/admin-client.yml
@@ -3,6 +3,14 @@
     name: "{{ proxysql_cli_client_package }}"
   when: proxysql_cli_install_client
 
+- name: "Install work-around for issue 1254"
+  cron:
+    cron_file: "ansible_1254_workaround"
+    minute: "1,16,31,46"
+    user: "root"
+    job: '/usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"'
+  when: proxysql_cli_install_config and proxysql_install_1254_workaround
+
 - name: "Write configuration file"
   template:
     src: "root_my.cnf.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,6 @@
 
 - name: "Install work-around for issue 1254"
   template:
-    src: template/cron_ansible_1254_workaround.j2
+    src: templates/cron_ansible_1254_workaround.j2
     dest: /etc/cron.d/ansible_1254_workaround
   when: proxysql_cli_install_config and proxysql_install_1254_workaround

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,3 +85,12 @@
   include_tasks: install-health-check.yml
   when: proxysql_cli_install_client and proxysql_cli_install_config and proxysql_install_health_check
   loop: "{{ proxysql_mysql_galera_hostgroups }}"
+
+- name: "Install work-around for issue 1254"
+  cron:
+    cron_file: "ansible_1254_workaround"
+    minute: "46"
+    hour: "1,4,7,10,13,16,19,22"
+    user: "root"
+    job: '/usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"'
+  when: proxysql_cli_install_config and proxysql_install_1254_workaround

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,11 +87,7 @@
   loop: "{{ proxysql_mysql_galera_hostgroups }}"
 
 - name: "Install work-around for issue 1254"
-  cron:
-    cron_file: "ansible_1254_workaround"
-    minute: "46"
-    hour: "1,4,7,10,13,16,19,22"
-    user: "root"
-    job: '/usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"'
-    name: "load_servers_to_runtime"
+  template:
+    src: template/cron_ansible_1254_workaround.j2
+    dest: /etc/cron.d/ansible_1254_workaround
   when: proxysql_cli_install_config and proxysql_install_1254_workaround

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,4 +93,5 @@
     hour: "1,4,7,10,13,16,19,22"
     user: "root"
     job: '/usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"'
+    name: "load_servers_to_runtime"
   when: proxysql_cli_install_config and proxysql_install_1254_workaround

--- a/templates/cron_ansible_1254_workaround.j2
+++ b/templates/cron_ansible_1254_workaround.j2
@@ -1,0 +1,2 @@
+# Ansible managed: Work-around for ProxySQL issue 1254
+46 1,4,7,10,13,16,19V,22 root /usr/bin/mysql -e "LOAD MYSQL SERVERS TO RUNTIME"

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -75,6 +75,7 @@ mysql_variables=
     commands_stats={{ proxysql_mysql_commands_stats }}
     sessions_sort={{ proxysql_mysql_sessions_sort }}
     connect_retries_on_failure={{ proxysql_mysql_connect_retries_on_failure }}
+    hostgroup_manager_verbose={{ proxysql_hostgroup_manager_verbose }}
 }
 
 # defines all the MySQL servers

--- a/templates/proxysql.cnf.j2
+++ b/templates/proxysql.cnf.j2
@@ -75,7 +75,7 @@ mysql_variables=
     commands_stats={{ proxysql_mysql_commands_stats }}
     sessions_sort={{ proxysql_mysql_sessions_sort }}
     connect_retries_on_failure={{ proxysql_mysql_connect_retries_on_failure }}
-    hostgroup_manager_verbose={{ proxysql_hostgroup_manager_verbose }}
+    hostgroup_manager_verbose={{ proxysql_mysql_hostgroup_manager_verbose }}
 }
 
 # defines all the MySQL servers


### PR DESCRIPTION
Work-around for issue https://github.com/sysown/proxysql/issues/1254 which causes nodes to dissapear from ProxySQL's running configurtion where writer is also reader.